### PR TITLE
Update Dockerfile van Geoserver

### DIFF
--- a/geoserver/Dockerfile
+++ b/geoserver/Dockerfile
@@ -8,4 +8,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt
 RUN rm /usr/local/geoserver/WEB-INF/lib/h2-1.1.119.jar
 RUN rm -rf /usr/local/tomcat/webapps.dist/*
 
+# tomcat user right for log
+RUN chown -R tomcat:tomcat /var/local/geoserver 
+
 COPY data_dir/ /var/local/geoserver


### PR DESCRIPTION
Gebruiker tomcat in de geoserver-docker is nu owner van de folder /var/local/geoserver , dit omdat initieel geen log-bestand aangemaakt kon worden.