### PR TITLE
Aanpassen pdok api url

### DIFF
--- a/backend/overstroomik_service/pdok.py
+++ b/backend/overstroomik_service/pdok.py
@@ -14,7 +14,7 @@ from overstroomik_service.errors import Errors
 class PDOK:
 
     # pdok api url
-    api = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/free"
+    api = "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free"
 
     # fields we need
     fields = "centroide_rd,centroide_ll,straatnaam,woonplaatsnaam,postcode"

--- a/backend/tests/test_pdok.py
+++ b/backend/tests/test_pdok.py
@@ -12,7 +12,7 @@ async def test_address_by_search_field_zip_code() -> None:
 
     assert status == Errors.ERROR_GENERAL_NOER
     assert location.latitude == 52.50669969
-    assert location.longitude == 5.46887432
+    assert location.longitude == 5.46887425 #5.46887432
     assert location.rd_x == 160544.902
     assert location.rd_y == 502115.495
     assert location.search_field == "8232JN"
@@ -30,7 +30,7 @@ async def test_address_by_latlon() -> None:
 
     assert status == Errors.ERROR_GENERAL_NOER
     assert location.latitude == 52.50669597
-    assert location.longitude == 5.46888296
+    assert location.longitude == 5.46888289
     assert location.rd_x == 160545.489
     assert location.rd_y == 502115.081
     assert location.search_field is None
@@ -43,7 +43,8 @@ async def test_address_by_latlon() -> None:
 async def test_fetch_data() -> None:
     pdok = PDOK()
 
-    url = "https://geodata.nationaalgeoregister.nl/locatieserver/v3/free"
+    url = "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free"
+
     fields = "centroide_rd,centroide_ll,straatnaam,woonplaatsnaam,postcode"
 
     latitude = 52.50669969
@@ -61,7 +62,7 @@ async def test_fetch_data() -> None:
 
     assert status == Errors.ERROR_GENERAL_NOER
     assert adress_item.get("latitude", 0) == 52.50669597
-    assert adress_item.get("longitude", 0) == 5.46888296
+    assert adress_item.get("longitude", 0) == 5.46888289 #5.46888296
     assert adress_item.get("address", "") == "Botter 11"
     assert adress_item.get("municipality", "") == "Lelystad"
     assert adress_item.get("zipcode", "") == "8232JN"

--- a/geoserver/Dockerfile
+++ b/geoserver/Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt
 RUN rm /usr/local/geoserver/WEB-INF/lib/h2-1.1.119.jar
 RUN rm -rf /usr/local/tomcat/webapps.dist/*
 
+# copy data to the geoserver folder
+COPY data_dir/ /var/local/geoserver
+
 # tomcat user right for log
 RUN chown -R tomcat:tomcat /var/local/geoserver 
 
-COPY data_dir/ /var/local/geoserver
+


### PR DESCRIPTION
Url naar pdok-api aangepast. 

was "https://geodata.nationaalgeoregister.nl/locatieserver/v3/free" (deze wordt na 2 augustus niet meer ondersteund)
is nu "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free?"

Testen of locatie zoeken op adres  of via lat/lon goed werkt. 
Unit test iets aangepast omdat latitude een minimale afwijking heeft via de nieuwe api.